### PR TITLE
Fix file read/write race, rename req to Subversion11.sfc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.spoiler.txt
+*.sfc
+__pycache__/
+*.swp

--- a/pullCSV.py
+++ b/pullCSV.py
@@ -1,6 +1,8 @@
 
 def pullCSV() :
 
+#"roomname","roomid","area","locid","plmtypeid","plmparam","xy","plmtypename","state","alternateroomid","alternateroomlocids"
+
     return [
 "IMPACT CRATER","7b820","0","3fff64,3fff9c,3fffda","f87e","0n0","[3e,38]","0xf87e","allstates","",""
 ,

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ contact randorandy (ironrusty) or strotlog with questions
 simple readme for now
 
 1.download this repository
-2.place a copy of the Subversion 1.1 rom in the roms folder - it must be named Subversion.smc
+2.place a copy of the Subversion 1.1 rom in the roms folder - it must be named Subversion11.sfc
 3.run Main.py in console
 
 This should create a randomized rom with the given name in the roms folder and a spoiler log (.txt) in the spoilers folder.

--- a/roms/rom_readme.txt
+++ b/roms/rom_readme.txt
@@ -1,3 +1,3 @@
 roms Readme
 
-Roms folder holds the output of roms and must include the already patched Subversion rom 1.1 named Subversion.smc
+Roms folder holds the output of roms and must include the already patched Subversion rom 1.1 named Subversion11.sfc


### PR DESCRIPTION
- Fixes the race
- For now it would be more clear to someone that they have the wrong ROM if we require a version number in its filename
- Also, .sfc is the more common file extension used by emulators, unless rusty's requires .smc for some reason? Some compilers actually enforce smc==headered(considered bad, we almost never use those in sm) vs. sfc==unheadered