### PR TITLE
web: Add flask seed rolling service

### DIFF
--- a/areaRando.py
+++ b/areaRando.py
@@ -1,5 +1,6 @@
 import random
 import io
+from romWriter import RomWriter
 
 #RandomizeAreas shuffles the locations and checks that the ship connects to daphne properly
 #updateAreaLogic is like a logic updater for area doors connecting to other area doors
@@ -211,7 +212,7 @@ SpaceJumpBoost = ["Space Jump Boost",
 spaceDrop = ["Space Drop","","","",""]
 
 
-def RandomizeAreas(rom) :
+def RandomizeAreas(romWriter : RomWriter) :
     #Each location holds
     #[0]the data of its door
     #[1]the data of the vanilla door that goes here
@@ -453,20 +454,14 @@ def RandomizeAreas(rom) :
         node1=pair[0]
         node2=pair[1]
         #place data for node1 sending
-        rom.seek(int(node1[0],16))
-        storeInt=int(node2[1],16)
-        rom.write(storeInt.to_bytes(12,'big'))
+        romWriter.writeBytes(int(node1[0],16), int(node2[1],16).to_bytes(12, 'big'))
         #place data for node2 sending
-        rom.seek(int(node2[0],16))
-        storeInt=int(node1[1],16)
-        rom.write(storeInt.to_bytes(12,'big'))
+        romWriter.writeBytes(int(node2[0],16), int(node1[1],16).to_bytes(12, 'big'))
         if node1[4] != node2[4] :
-            rom.seek(int(node1[0],16)+2)
-            rom.write(b"\x40")
-            rom.seek(int(node2[0],16)+2)
-            rom.write(b"\x40")
+            romWriter.writeBytes(int(node1[0],16)+2, b"\x40")
+            romWriter.writeBytes(int(node2[0],16)+2, b"\x40")
 
-    #Area rando done?        
+    #Area rando done?
 
     #coloring some doors to be flashing
     colorDoorsR=['3fff70',
@@ -476,27 +471,23 @@ def RandomizeAreas(rom) :
                  '3ff1f8',
                  '3fe668',
                  '3fe66e']
-                 
-                 
+
+
     colorDoorsL=['3ffec4',
                  '3fe352',
                  '3fe35a',
                  '3fe686',
                  '3ffa2c']
-                 
-                 
-    for item in colorDoorsR :
-        rom.seek(int(item,16))
-        rom.write(b"\x42")       
-        rom.seek(int(item,16)+5)
-        rom.write(b"\x98")
-    for item in colorDoorsL :
-        rom.seek(int(item,16))
-        rom.write(b"\x48")
-        rom.seek(int(item,16)+5)
-        rom.write(b"\x98")
 
-    return rom, Connections
+
+    for doorlocid in colorDoorsR:
+        romWriter.writeBytes(int(doorlocid,16),   b"\x42") # gray type door
+        romWriter.writeBytes(int(doorlocid,16)+5, b"\x98") # animals subtype
+    for doorlocid in colorDoorsL:
+        romWriter.writeBytes(int(doorlocid,16),   b"\x48") # gray type door
+        romWriter.writeBytes(int(doorlocid,16)+5, b"\x98") # animals subtype
+
+    return Connections
 
 def otherDoor(door,Connections) :
     for pair in Connections :

--- a/flaskapp.py
+++ b/flaskapp.py
@@ -1,0 +1,16 @@
+import flask
+import Main
+from romWriter import RomWriter
+
+app = flask.Flask(__name__)
+
+@app.route('/rollseed')
+def roll_seed():
+    argv = ['dummyexe']
+    argv.extend(flask.request.args.get('argv', default="").split())
+    romWriter = RomWriter.fromBlankIps()
+    Main.Main(argv, romWriter)
+    response = flask.make_response(romWriter.getFinalIps())
+    response.headers['Content-Type'] = 'application/octet-stream'
+    response.headers['Content-Disposition'] = f'attachment; filename={romWriter.getBaseFilename()}.ips'
+    return response

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+click==8.1.3
+Flask==2.2.2
+importlib-metadata==5.0.0
+itsdangerous==2.1.2
+Jinja2==3.1.2
+MarkupSafe==2.1.1
+Werkzeug==2.2.2
+zipp==3.10.0

--- a/romWriter.py
+++ b/romWriter.py
@@ -1,0 +1,99 @@
+import io
+import enum
+import os
+
+class RomWriterType(enum.Enum):
+    file = 1
+    ipsblob = 2
+
+class RomWriter:
+    def __init__(self):
+        self.romWriterType : RomWriterType = 0
+        self.romFile : io.BufferedIOBase = None
+        self.ipsblob : bytearray = None
+        self.baseFilename : str = ''
+
+    @classmethod
+    def fromFilePaths(cls, origRomPath: str, newRomPath: str):
+        instance = cls()
+        instance.romWriterType = RomWriterType.file
+        instance.romFile = RomWriter.createWorkingFileCopy(origRomPath, newRomPath)
+        return instance
+
+    @classmethod
+    def fromBlankIps(cls):
+        instance = cls()
+        instance.romWriterType = RomWriterType.ipsblob
+        instance.ipsblob = bytearray(b'PATCH')
+        return instance
+
+
+    def createWorkingFileCopy(origFile, newFile) -> io.BufferedIOBase:
+        if not os.path.exists(origFile):
+            raise Exception(f'origFile not found: {origFile}')
+        with open(origFile, 'rb') as orig:
+            romFile = open(newFile, 'wb') # wb = write, binary
+            # copy original to new before we edit new
+            while True:
+                chunk = orig.read(16384) # or any amount
+                if chunk == b"":
+                    break
+                romFile.write(chunk)
+            return romFile
+
+
+    def isAllRepeatedBytes(data):
+        if len(data) < 2:
+            return False
+        byte = data[0]
+        for i in range(1, len(data)):
+            if data[i] != byte:
+               return False
+        return True
+
+
+    def writeBytes(self, address : int, data):
+        if self.romWriterType == RomWriterType.file:
+            self.romFile.seek(address)
+            self.romFile.write(data)
+        elif self.romWriterType == RomWriterType.ipsblob:
+            if len(data) >= 65536:
+                raise Exception(f'data length {len(data)} exceeds max IPS len of 65536')
+            self.ipsblob.extend(address.to_bytes(3, 'big'))
+            if len(data) > 10 and RomWriter.isAllRepeatedBytes(data):
+                # RLE encode
+                self.ipsblob.extend(b'\x00\x00')
+                self.ipsblob.extend(len(data).to_bytes(2, 'big'))
+                self.ipsblob.append(data[0])
+            else:
+                # normal patch data
+                self.ipsblob.extend(len(data).to_bytes(2, 'big'))
+                self.ipsblob.extend(data)
+
+
+    def writeItem(self, address : int, plmid, ammoAmount = b"\x00"):
+        if len(plmid) != 2 or len(ammoAmount) != 1:
+            raise Exception(f'plmid length ({len(plmid)}) must be 2 and ammoAmount length ({len(ammoAmount)}) must be 1')
+        self.writeBytes(address, plmid)
+        self.writeBytes(address+5, ammoAmount)
+
+
+    def finalizeRom(self):
+        if self.romWriterType == RomWriterType.file:
+            self.romFile.close()
+            self.romFile = None
+        elif self.romWriterType == RomWriterType.ipsblob:
+            self.ipsblob.extend(b'EOF')
+
+    def getFinalIps(self) -> bytearray:
+        if self.romWriterType != RomWriterType.ipsblob:
+            raise Exception('getFinalIps() called on non-ipsblob-typed RomWriter')
+        if bytes(self.ipsblob[-3:]) != b'EOF':
+            raise Exception('getFinalIps() called before finalizeRom()')
+        return self.ipsblob
+
+    def setBaseFilename(self, baseFilename : str):
+        self.baseFilename = baseFilename
+
+    def getBaseFilename(self) -> str:
+        return self.baseFilename


### PR DESCRIPTION
- Refactor the ROM writes allowing them to be redirected to a .ips format.
- Add a very simple flask app that calls into Main.py to roll a seed and return a well-named IPS download file. Settings can be passed in the query string as if running from the command line. This could be `fetch()`ed from a Javascript frontend.
- requirements.txt needs to be installed (via pip, preferably into a virtualenv) for anyone wanting to use flask. These steps shouldn't be needed for command-line use (for now, anyway).
- Does NOT return a spoiler log, nor any exceptions thrown, nor anything printed in Python. These things are theoretically possible.