### PR TITLE
door logic interface

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -141,7 +141,7 @@ def Main(argv: list[str], romWriter: Optional[RomWriter] = None) -> None:
         unusedLocations.extend(locArray)
         availableLocations: list[Location] = []
         # visitedLocations = []
-        loadout = Loadout(Expert if logicChoice == "E" else Casual)
+        loadout = Loadout(Expert if logicChoice == "E" else Casual, randomizeAreas)
         loadout.append(SunkenNestL)  # starting area
         # use appropriate fill algorithm for initializing item lists
         fill_algorithm = fillers[fillChoice]()

--- a/connection_data.py
+++ b/connection_data.py
@@ -1,4 +1,6 @@
 """ data for the connections in area rando """
+from item_data import Item, Items
+
 
 AreaDoor = tuple[str, str, str, str, int]
 """
@@ -64,6 +66,13 @@ area_doors_unpackable: tuple[AreaDoor, ...] = (
 area_doors: dict[str, AreaDoor] = {
     door[3]: door
     for door in area_doors_unpackable
+}
+
+vanilla_doors: dict[AreaDoor, Item] = {
+    area_doors["CraterR"]: Items.PowerBomb,
+    area_doors["WestTerminalAccessL"]: Items.PowerBomb,
+    area_doors["VulnarCanyonL"]: Items.PowerBomb,
+    area_doors["FoyerR"]: Items.Super
 }
 
 # to make sure this unpacking list is correct:

--- a/door_logic.py
+++ b/door_logic.py
@@ -4,6 +4,6 @@ from logic_shortcut import LogicShortcut
 
 def canOpen(door: AreaDoor) -> LogicShortcut:
     return LogicShortcut(lambda loadout: (
-        (loadout.area_rando and door[3] in area_doors) or
-        loadout.door_data[door] in loadout
+        (loadout.game.area_rando and door[3] in area_doors) or
+        loadout.game.door_data[door] in loadout
     ))

--- a/door_logic.py
+++ b/door_logic.py
@@ -1,0 +1,9 @@
+from connection_data import AreaDoor, area_doors
+from logic_shortcut import LogicShortcut
+
+
+def canOpen(door: AreaDoor) -> LogicShortcut:
+    return LogicShortcut(lambda loadout: (
+        (loadout.area_rando and door[3] in area_doors) or
+        loadout.door_data[door] in loadout
+    ))

--- a/fillInterface.py
+++ b/fillInterface.py
@@ -13,7 +13,6 @@ class FillAlgorithm(abc.ABC):
     @abc.abstractmethod
     def choose_placement(self,
                          availableLocations: list[Location],
-                         locArray: list[Location],
                          loadout: Loadout) -> Optional[tuple[Location, Item]]:
         """ returns (location to place an item, which item to place there) """
 

--- a/fillMajorMinor.py
+++ b/fillMajorMinor.py
@@ -117,7 +117,6 @@ class FillMajorMinor(FillAlgorithm):
 
     def choose_placement(self,
                          availableLocations: list[Location],
-                         locArray: list[Location],
                          loadout: Loadout) -> Optional[tuple[Location, Item]]:
         """ returns (location to place an item, which item to place there) """
 
@@ -152,7 +151,7 @@ class FillMajorMinor(FillAlgorithm):
                 if (loc['fullitemname'] in majorLocs)
             ]
             if from_items is self.earlyItemList and len(valid_locations) == 0 and (Morph in loadout):
-                for sandySearch in locArray:
+                for sandySearch in loadout.game.all_locations:
                     # print("Searching for Sandy Cache: ", sandySearch['fullitemname'])
                     if sandySearch['fullitemname'] == "Sandy Cache":
                         # print("   ---   appending sandy cache")

--- a/fillMedium.py
+++ b/fillMedium.py
@@ -96,7 +96,6 @@ class FillMedium(FillAlgorithm):
 
     def choose_placement(self,
                          availableLocations: list[Location],
-                         locArray: list[Location],
                          loadout: Loadout) -> Optional[tuple[Location, Item]]:
         """ returns (location to place an item, which item to place there) """
         assert len(availableLocations), "placement algorithm received 0 available locations"

--- a/fillSpeedrun.py
+++ b/fillSpeedrun.py
@@ -85,7 +85,6 @@ class FillSpeedrun(FillAlgorithm):
 
     def choose_placement(self,
                          availableLocations: list[Location],
-                         locArray: list[Location],
                          loadout: Loadout) -> Optional[tuple[Location, Item]]:
         """ returns (location to place an item, which item to place there) """
         assert len(availableLocations), "placement algorithm received 0 available locations"

--- a/game.py
+++ b/game.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass, field
+from typing import Mapping, Type
+
+from connection_data import AreaDoor, vanilla_doors
+from item_data import Item
+from location_data import Location
+from logicInterface import LogicInterface
+
+
+def door_factory() -> dict[AreaDoor, Item]:
+    return vanilla_doors
+
+
+@dataclass
+class Game:
+    """ a composition of all the components that make up the generated seed """
+    logic: Type[LogicInterface]
+    all_locations: list[Location]
+    area_rando: bool
+    connections: list[tuple[AreaDoor, AreaDoor]]
+    door_data: Mapping[AreaDoor, Item] = field(default_factory=door_factory)

--- a/loadout.py
+++ b/loadout.py
@@ -1,7 +1,7 @@
 from collections import Counter
-from typing import TYPE_CHECKING, Any, Iterable, Iterator, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Iterable, Iterator, Mapping, Optional, Type, Union
 
-from connection_data import AreaDoor
+from connection_data import AreaDoor, vanilla_doors
 from item_data import Item
 from logic_shortcut import LogicShortcut
 
@@ -25,12 +25,19 @@ class ItemCounter(Counter[Union[Item, AreaDoor]]):
 
 
 class Loadout:
-    contents: ItemCounter
     logic: "Type[LogicInterface]"
+    area_rando: bool
+    contents: ItemCounter
+    door_data: Mapping[AreaDoor, Item]
 
-    def __init__(self, logic: "Type[LogicInterface]", items: Optional[Iterable[Union[Item, AreaDoor]]] = None) -> None:
-        self.contents = ItemCounter(items)
+    def __init__(self,
+                 logic: "Type[LogicInterface]",
+                 area_rando: bool,
+                 items: Optional[Iterable[Union[Item, AreaDoor]]] = None) -> None:
         self.logic = logic
+        self.area_rando = area_rando
+        self.contents = ItemCounter(items)
+        self.door_data = vanilla_doors
 
     def __eq__(self, __o: object) -> bool:
         if not isinstance(__o, Loadout):
@@ -70,4 +77,4 @@ class Loadout:
 
     def copy(self) -> "Loadout":
         # TODO: test copy
-        return Loadout(self.logic, self.contents)
+        return Loadout(self.logic, self.area_rando, self.contents)

--- a/loadout.py
+++ b/loadout.py
@@ -1,12 +1,12 @@
 from collections import Counter
-from typing import TYPE_CHECKING, Any, Iterable, Iterator, Mapping, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Iterable, Iterator, Optional, Union
 
-from connection_data import AreaDoor, vanilla_doors
+from connection_data import AreaDoor
 from item_data import Item
 from logic_shortcut import LogicShortcut
 
 if TYPE_CHECKING:
-    from logicInterface import LogicInterface
+    from game import Game
 
 
 class ItemCounter(Counter[Union[Item, AreaDoor]]):
@@ -25,26 +25,20 @@ class ItemCounter(Counter[Union[Item, AreaDoor]]):
 
 
 class Loadout:
-    logic: "Type[LogicInterface]"
-    area_rando: bool
     contents: ItemCounter
-    door_data: Mapping[AreaDoor, Item]
 
     def __init__(self,
-                 logic: "Type[LogicInterface]",
-                 area_rando: bool,
+                 game: "Game",
                  items: Optional[Iterable[Union[Item, AreaDoor]]] = None) -> None:
-        self.logic = logic
-        self.area_rando = area_rando
+        self.game = game
         self.contents = ItemCounter(items)
-        self.door_data = vanilla_doors
 
     def __eq__(self, __o: object) -> bool:
         if not isinstance(__o, Loadout):
             return False
         return (
             (self.contents == __o.contents) and
-            (self.logic is __o.logic)
+            (self.game is __o.game)
         )
 
     def __contains__(self, x: Union[Item, AreaDoor, LogicShortcut]) -> bool:
@@ -61,7 +55,7 @@ class Loadout:
         return sum(self.contents.values())  # `Counter.total()` requires python 3.10
 
     def __repr__(self) -> str:
-        return f"Loadout({self.logic.__name__}, {self.contents})"
+        return f"Loadout({self.game}, {self.contents})"
 
     def count(self, item: Union[Item, AreaDoor]) -> int:
         return self.contents[item]
@@ -77,4 +71,4 @@ class Loadout:
 
     def copy(self) -> "Loadout":
         # TODO: test copy
-        return Loadout(self.logic, self.area_rando, self.contents)
+        return Loadout(self.game, self.contents)

--- a/logicCasual.py
+++ b/logicCasual.py
@@ -1,5 +1,7 @@
 from typing import ClassVar
+
 from connection_data import area_doors_unpackable
+from door_logic import canOpen
 from item_data import items_unpackable
 from loadout import Loadout
 from logicCommon import energy_req
@@ -105,7 +107,7 @@ area_logic: AreaLogicType = {
             canFly in loadout
         ),  # this location cares about area rando
         ("SunkenNestL", "CraterR"): lambda loadout: (
-            loadout.has_all(canFly, canUsePB)
+            loadout.has_all(canFly, canOpen(CraterR))
         ),  # this location cares about area rando
         ("SunkenNestL", "RuinedConcourseBL"): lambda loadout: (
             (jumpAble in loadout) and

--- a/logicExpert.py
+++ b/logicExpert.py
@@ -1,5 +1,7 @@
 from typing import ClassVar
+
 from connection_data import area_doors_unpackable
+from door_logic import canOpen
 from item_data import items_unpackable
 from loadout import Loadout
 from logicCommon import energy_req, varia_or_hell_run
@@ -108,7 +110,7 @@ area_logic: AreaLogicType = {
             canFly in loadout
         ),
         ("SunkenNestL", "CraterR"): lambda loadout: (
-            loadout.has_all(canFly, canUsePB)
+            loadout.has_all(canFly, canOpen(CraterR))
         ),
         ("SunkenNestL", "RuinedConcourseBL"): lambda loadout: (
             (jumpAble in loadout) and

--- a/logic_updater.py
+++ b/logic_updater.py
@@ -13,16 +13,15 @@ def otherDoor(door: AreaDoor, Connections: list[tuple[AreaDoor, AreaDoor]]) -> A
     raise ValueError(f"door {door} is not in Connections {[(c[0][3], c[1][3]) for c in Connections]}")
 
 
-def updateAreaLogic(loadout: Loadout,
-                    connections: list[tuple[AreaDoor, AreaDoor]]) -> None:
+def updateAreaLogic(loadout: Loadout) -> None:
     stuck = False  # check if loadout keeps increasing
     while not stuck:
         prev_loadout = loadout.copy()
-        for _area, paths in loadout.logic.area_logic.items():
+        for _area, paths in loadout.game.logic.area_logic.items():
             for path, access in paths.items():
                 origin, destination = path
                 if area_doors[destination] not in loadout:
-                    other = otherDoor(area_doors[destination], connections)
+                    other = otherDoor(area_doors[destination], loadout.game.connections)
                     if other in loadout:
                         loadout.append(area_doors[destination])
                     elif (area_doors[origin] in loadout) and access(loadout):
@@ -33,10 +32,9 @@ def updateAreaLogic(loadout: Loadout,
 
 
 def updateLogic(unusedLocations: list[Location],
-                locArray: list[Location],
                 loadout: Loadout) -> list[Location]:
     # print("Updating logic...")
     for thisLoc in unusedLocations:
-        thisLoc['inlogic'] = loadout.logic.location_logic[thisLoc['fullitemname']](loadout)
+        thisLoc['inlogic'] = loadout.game.logic.location_logic[thisLoc['fullitemname']](loadout)
 
     return unusedLocations

--- a/solver.py
+++ b/solver.py
@@ -1,6 +1,6 @@
 from typing import Type
 
-from connection_data import AreaDoor, SunkenNestL
+from connection_data import AreaDoor, SunkenNestL, VanillaAreas
 from item_data import Items
 from loadout import Loadout
 from location_data import Location, spacePortLocs
@@ -45,7 +45,7 @@ def solve(all_locations: list[Location],
     unused_locations = all_locations.copy()
     used_locs: set[str] = set()
 
-    loadout = Loadout(logic)
+    loadout = Loadout(logic, connections != VanillaAreas())
 
     log_lines = [" - spaceport -"]
     # this loop just for spaceport

--- a/solver.py
+++ b/solver.py
@@ -1,10 +1,8 @@
-from typing import Type
-
-from connection_data import AreaDoor, SunkenNestL, VanillaAreas
+from connection_data import SunkenNestL
+from game import Game
 from item_data import Items
 from loadout import Loadout
-from location_data import Location, spacePortLocs
-from logicInterface import LogicInterface
+from location_data import spacePortLocs
 from logic_updater import updateAreaLogic, updateLogic
 
 _progression_items = frozenset([
@@ -35,17 +33,15 @@ _progression_items = frozenset([
 ])
 
 
-def solve(all_locations: list[Location],
-          logic: Type[LogicInterface],
-          connections: list[tuple[AreaDoor, AreaDoor]]) -> tuple[bool, list[str]]:
+def solve(game: Game) -> tuple[bool, list[str]]:
     """ returns (whether completable, spoiler lines) """
-    for loc in all_locations:
+    for loc in game.all_locations:
         loc['inlogic'] = False
 
-    unused_locations = all_locations.copy()
+    unused_locations = game.all_locations.copy()
     used_locs: set[str] = set()
 
-    loadout = Loadout(logic, connections != VanillaAreas())
+    loadout = Loadout(game)
 
     log_lines = [" - spaceport -"]
     # this loop just for spaceport
@@ -53,8 +49,8 @@ def solve(all_locations: list[Location],
     while not stuck:
         prev_loadout_count = len(loadout)
         log_lines.append("sphere:")
-        updateAreaLogic(loadout, connections)
-        updateLogic(unused_locations, all_locations, loadout)
+        updateAreaLogic(loadout)
+        updateLogic(unused_locations, loadout)
         for loc in unused_locations:
             if loc['inlogic']:
                 loc_name = loc['fullitemname']
@@ -75,7 +71,7 @@ def solve(all_locations: list[Location],
     while "sphere:" in log_lines[-1]:
         log_lines.pop()
 
-    if not logic.can_fall_from_spaceport(loadout):
+    if not game.logic.can_fall_from_spaceport(loadout):
         print("solver: couldn't get out of spaceport")
         for loc in unused_locations:
             if loc['inlogic'] and loc['fullitemname'] not in spacePortLocs:
@@ -91,8 +87,8 @@ def solve(all_locations: list[Location],
     while not stuck:
         prev_loadout_count = len(loadout)
         log_lines.append("sphere:")
-        updateAreaLogic(loadout, connections)
-        updateLogic(unused_locations, all_locations, loadout)
+        updateAreaLogic(loadout)
+        updateLogic(unused_locations, loadout)
         for loc in unused_locations:
             if loc['inlogic']:
                 loc_name = loc['fullitemname']

--- a/tests/test_door_logic.py
+++ b/tests/test_door_logic.py
@@ -2,6 +2,8 @@
 import sys
 from pathlib import Path
 
+from game import Game
+
 file = Path(__file__).resolve()
 parent, root = file.parent, file.parents[1]
 sys.path.append(str(root))
@@ -14,8 +16,8 @@ from logicCasual import Casual
 
 
 def test_area_rando() -> None:
-    area_rando = True
-    loadout = Loadout(Casual, area_rando)
+    game = Game(Casual, [], True, [])
+    loadout = Loadout(game)
 
     assert canOpen(area_doors["CraterR"]) in loadout
     assert canOpen(area_doors["WestTerminalAccessL"]) in loadout
@@ -24,8 +26,8 @@ def test_area_rando() -> None:
 
 
 def test_area_rando_with_items() -> None:
-    area_rando = True
-    loadout = Loadout(Casual, area_rando, (Items.PowerBomb, Items.Super))
+    game = Game(Casual, [], True, [])
+    loadout = Loadout(game, (Items.PowerBomb, Items.Super))
 
     assert canOpen(area_doors["CraterR"]) in loadout
     assert canOpen(area_doors["WestTerminalAccessL"]) in loadout
@@ -34,8 +36,8 @@ def test_area_rando_with_items() -> None:
 
 
 def test_non_area_rando_locked() -> None:
-    area_rando = False
-    loadout = Loadout(Casual, area_rando)
+    game = Game(Casual, [], False, [])
+    loadout = Loadout(game)
 
     assert canOpen(area_doors["CraterR"]) not in loadout
     assert canOpen(area_doors["WestTerminalAccessL"]) not in loadout
@@ -44,8 +46,8 @@ def test_non_area_rando_locked() -> None:
 
 
 def test_non_area_rando_open() -> None:
-    area_rando = False
-    loadout = Loadout(Casual, area_rando, (Items.PowerBomb, Items.Super))
+    game = Game(Casual, [], False, [])
+    loadout = Loadout(game, (Items.PowerBomb, Items.Super))
 
     assert canOpen(area_doors["CraterR"]) in loadout
     assert canOpen(area_doors["WestTerminalAccessL"]) in loadout

--- a/tests/test_door_logic.py
+++ b/tests/test_door_logic.py
@@ -1,0 +1,53 @@
+# import hacks, because this project is not a python package
+import sys
+from pathlib import Path
+
+file = Path(__file__).resolve()
+parent, root = file.parent, file.parents[1]
+sys.path.append(str(root))
+
+from connection_data import area_doors
+from door_logic import canOpen
+from item_data import Items
+from loadout import Loadout
+from logicCasual import Casual
+
+
+def test_area_rando() -> None:
+    area_rando = True
+    loadout = Loadout(Casual, area_rando)
+
+    assert canOpen(area_doors["CraterR"]) in loadout
+    assert canOpen(area_doors["WestTerminalAccessL"]) in loadout
+    assert canOpen(area_doors["VulnarCanyonL"]) in loadout
+    assert canOpen(area_doors["FoyerR"]) in loadout
+
+
+def test_area_rando_with_items() -> None:
+    area_rando = True
+    loadout = Loadout(Casual, area_rando, (Items.PowerBomb, Items.Super))
+
+    assert canOpen(area_doors["CraterR"]) in loadout
+    assert canOpen(area_doors["WestTerminalAccessL"]) in loadout
+    assert canOpen(area_doors["VulnarCanyonL"]) in loadout
+    assert canOpen(area_doors["FoyerR"]) in loadout
+
+
+def test_non_area_rando_locked() -> None:
+    area_rando = False
+    loadout = Loadout(Casual, area_rando)
+
+    assert canOpen(area_doors["CraterR"]) not in loadout
+    assert canOpen(area_doors["WestTerminalAccessL"]) not in loadout
+    assert canOpen(area_doors["VulnarCanyonL"]) not in loadout
+    assert canOpen(area_doors["FoyerR"]) not in loadout
+
+
+def test_non_area_rando_open() -> None:
+    area_rando = False
+    loadout = Loadout(Casual, area_rando, (Items.PowerBomb, Items.Super))
+
+    assert canOpen(area_doors["CraterR"]) in loadout
+    assert canOpen(area_doors["WestTerminalAccessL"]) in loadout
+    assert canOpen(area_doors["VulnarCanyonL"]) in loadout
+    assert canOpen(area_doors["FoyerR"]) in loadout

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -4,11 +4,13 @@ from pathlib import Path
 from typing import Type
 import pytest
 
+from game import Game
+
 file = Path(__file__).resolve()
 parent, root = file.parent, file.parents[1]
 sys.path.append(str(root))
 
-from connection_data import AreaDoor, SunkenNestL, VanillaAreas
+from connection_data import SunkenNestL, VanillaAreas
 from item_data import Items, items_unpackable
 from loadout import Loadout
 from location_data import Location, pullCSV
@@ -18,25 +20,22 @@ from logicInterface import LogicInterface
 from logic_updater import updateAreaLogic, updateLogic
 
 
-def setup(logic: Type[LogicInterface]) -> tuple[
-    list[Location], list[tuple[AreaDoor, AreaDoor]], Loadout
-]:
+def setup(logic: Type[LogicInterface]) -> tuple[Game, Loadout]:
     """ returns (all locations, vanilla connections, a new loadout) """
     locations = pullCSV()
-    all_locations = list(locations.values())
-    connections = VanillaAreas()
-    loadout = Loadout(logic, False)
-    return all_locations, connections, loadout
+    game = Game(logic, list(locations.values()), False, VanillaAreas())
+    loadout = Loadout(game)
+    return game, loadout
 
 
 def test_start_logic() -> None:
-    all_locations, connections, loadout = setup(Casual)
+    game, loadout = setup(Casual)
 
     def update_acc() -> list[Location]:
-        updateAreaLogic(loadout, connections)
-        updateLogic(all_locations, all_locations, loadout)
+        updateAreaLogic(loadout)
+        updateLogic(game.all_locations, loadout)
 
-        return [loc for loc in all_locations if loc['inlogic']]
+        return [loc for loc in game.all_locations if loc['inlogic']]
 
     accessible = update_acc()
     assert len(accessible) == 1, f"accessible len {len(accessible)}"
@@ -56,7 +55,8 @@ def test_start_logic() -> None:
         print(loc["fullitemname"])
     assert len(accessible) == 4, "add Ocean Shore: bottom"
 
-    loadout = Loadout(Expert, False, loadout.contents)
+    game, _ = setup(Expert)
+    loadout = Loadout(game, loadout.contents)
 
     accessible = update_acc()
     print("  with expert")
@@ -74,7 +74,7 @@ def test_start_logic() -> None:
 
 @pytest.mark.parametrize("logic", (Casual, Expert))
 def test_all_locations(logic: Type[LogicInterface]) -> None:
-    all_locations, connections, loadout = setup(logic)
+    game, loadout = setup(logic)
 
     loadout.append(SunkenNestL)
     loadout.append(Items.spaceDrop)
@@ -83,16 +83,16 @@ def test_all_locations(logic: Type[LogicInterface]) -> None:
     for _ in range(10):
         loadout.append(Items.Energy)
 
-    updateAreaLogic(loadout, connections)
-    updateLogic(all_locations, all_locations, loadout)
+    updateAreaLogic(loadout)
+    updateLogic(game.all_locations, loadout)
 
-    accessible = [loc for loc in all_locations if loc['inlogic']]
+    accessible = [loc for loc in game.all_locations if loc['inlogic']]
 
     assert len(accessible) == 122, f"acc len {len(accessible)}"
 
 
 def test_casual_no_hell_runs() -> None:
-    all_locations, connections, loadout = setup(Casual)
+    game, loadout = setup(Casual)
 
     loadout.append(SunkenNestL)
     loadout.append(Items.spaceDrop)
@@ -102,16 +102,16 @@ def test_casual_no_hell_runs() -> None:
     for _ in range(16):
         loadout.append(Items.Energy)
 
-    updateAreaLogic(loadout, connections)
-    updateLogic(all_locations, all_locations, loadout)
+    updateAreaLogic(loadout)
+    updateLogic(game.all_locations, loadout)
 
-    accessible = [loc for loc in all_locations if loc['inlogic']]
+    accessible = [loc for loc in game.all_locations if loc['inlogic']]
 
     assert len(accessible) < 110, f"acc len {len(accessible)}"
 
 
 def test_expert_hell_runs() -> None:
-    all_locations, connections, loadout = setup(Expert)
+    game, loadout = setup(Expert)
 
     loadout.append(SunkenNestL)
     loadout.append(Items.spaceDrop)
@@ -121,14 +121,14 @@ def test_expert_hell_runs() -> None:
     for _ in range(16):
         loadout.append(Items.Energy)
 
-    updateAreaLogic(loadout, connections)
-    updateLogic(all_locations, all_locations, loadout)
+    updateAreaLogic(loadout)
+    updateLogic(game.all_locations, loadout)
 
-    accessible = [loc for loc in all_locations if loc['inlogic']]
+    accessible = [loc for loc in game.all_locations if loc['inlogic']]
 
     assert len(accessible) == 122, (
         "expert can't get these without varia: "
-        f"{[loc['fullitemname'] for loc in all_locations if not loc['inlogic']]}"
+        f"{[loc['fullitemname'] for loc in game.all_locations if not loc['inlogic']]}"
     )
 
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -4,8 +4,6 @@ from pathlib import Path
 from typing import Type
 import pytest
 
-from logicInterface import LogicInterface
-
 file = Path(__file__).resolve()
 parent, root = file.parent, file.parents[1]
 sys.path.append(str(root))
@@ -16,6 +14,7 @@ from loadout import Loadout
 from location_data import Location, pullCSV
 from logicCasual import Casual
 from logicExpert import Expert
+from logicInterface import LogicInterface
 from logic_updater import updateAreaLogic, updateLogic
 
 
@@ -26,7 +25,7 @@ def setup(logic: Type[LogicInterface]) -> tuple[
     locations = pullCSV()
     all_locations = list(locations.values())
     connections = VanillaAreas()
-    loadout = Loadout(logic)
+    loadout = Loadout(logic, False)
     return all_locations, connections, loadout
 
 
@@ -57,7 +56,7 @@ def test_start_logic() -> None:
         print(loc["fullitemname"])
     assert len(accessible) == 4, "add Ocean Shore: bottom"
 
-    loadout = Loadout(Expert, loadout.contents)
+    loadout = Loadout(Expert, False, loadout.contents)
 
     accessible = update_acc()
     print("  with expert")

--- a/tests/test_logic_shortcuts.py
+++ b/tests/test_logic_shortcuts.py
@@ -3,8 +3,6 @@ import sys
 from pathlib import Path
 import pytest
 
-from logicExpert import Expert
-
 file = Path(__file__).resolve()
 parent, root = file.parent, file.parents[1]
 sys.path.append(str(root))
@@ -13,6 +11,7 @@ from item_data import Items
 from loadout import Loadout
 from logicCasual import Casual
 from logicCommon import energy_from_tanks, energy_req, varia_or_hell_run
+from logicExpert import Expert
 from logic_shortcut import LogicShortcut
 
 
@@ -33,7 +32,7 @@ def test_energy_from_tanks() -> None:
 
 
 def test_energy_req() -> None:
-    loadout = Loadout(Casual, (Items.Energy for _ in range(10)))
+    loadout = Loadout(Casual, False, (Items.Energy for _ in range(10)))
 
     assert energy_req(900) in loadout
     assert energy_req(1100) not in loadout
@@ -43,11 +42,11 @@ def test_energy_req() -> None:
 
     assert energy_req(1100) in loadout
 
-    loadout = Loadout(Casual)  # empty
+    loadout = Loadout(Casual, False)  # empty
 
     assert energy_req(900) not in loadout
 
-    loadout = Loadout(Expert)  # empty
+    loadout = Loadout(Expert, False)  # empty
 
     assert energy_req(700) not in loadout
 
@@ -64,7 +63,7 @@ def test_energy_req() -> None:
 
 
 def test_varia_or_hell_run() -> None:
-    loadout = Loadout(Expert)
+    loadout = Loadout(Expert, False)
 
     assert varia_or_hell_run(400) not in loadout
     assert varia_or_hell_run(800) not in loadout
@@ -90,7 +89,7 @@ def test_varia_or_hell_run() -> None:
     assert varia_or_hell_run(1200) in loadout
     assert varia_or_hell_run(1400) in loadout
 
-    loadout = Loadout(Expert)
+    loadout = Loadout(Expert, False)
     loadout.append(Items.Varia)  # only varia, no energy
 
     assert varia_or_hell_run(400) in loadout
@@ -112,7 +111,7 @@ def test_use_as_bool() -> None:
         (Items.Bombs in loadout) and
         (Items.Morph in loadout)
     ))
-    loadout = Loadout(Casual)
+    loadout = Loadout(Casual, False)
 
     with pytest.raises(TypeError):
         _ = (

--- a/tests/test_logic_shortcuts.py
+++ b/tests/test_logic_shortcuts.py
@@ -2,6 +2,7 @@
 import sys
 from pathlib import Path
 import pytest
+from game import Game
 
 file = Path(__file__).resolve()
 parent, root = file.parent, file.parents[1]
@@ -32,7 +33,8 @@ def test_energy_from_tanks() -> None:
 
 
 def test_energy_req() -> None:
-    loadout = Loadout(Casual, False, (Items.Energy for _ in range(10)))
+    game = Game(Casual, [], False, [])
+    loadout = Loadout(game, (Items.Energy for _ in range(10)))
 
     assert energy_req(900) in loadout
     assert energy_req(1100) not in loadout
@@ -42,11 +44,12 @@ def test_energy_req() -> None:
 
     assert energy_req(1100) in loadout
 
-    loadout = Loadout(Casual, False)  # empty
+    loadout = Loadout(game)  # empty
 
     assert energy_req(900) not in loadout
 
-    loadout = Loadout(Expert, False)  # empty
+    game = Game(Expert, [], False, [])
+    loadout = Loadout(game)  # empty
 
     assert energy_req(700) not in loadout
 
@@ -63,7 +66,8 @@ def test_energy_req() -> None:
 
 
 def test_varia_or_hell_run() -> None:
-    loadout = Loadout(Expert, False)
+    game = Game(Expert, [], False, [])
+    loadout = Loadout(game)
 
     assert varia_or_hell_run(400) not in loadout
     assert varia_or_hell_run(800) not in loadout
@@ -89,7 +93,7 @@ def test_varia_or_hell_run() -> None:
     assert varia_or_hell_run(1200) in loadout
     assert varia_or_hell_run(1400) in loadout
 
-    loadout = Loadout(Expert, False)
+    loadout = Loadout(game)
     loadout.append(Items.Varia)  # only varia, no energy
 
     assert varia_or_hell_run(400) in loadout
@@ -111,7 +115,8 @@ def test_use_as_bool() -> None:
         (Items.Bombs in loadout) and
         (Items.Morph in loadout)
     ))
-    loadout = Loadout(Casual, False)
+    game = Game(Casual, [], False, [])
+    loadout = Loadout(game)
 
     with pytest.raises(TypeError):
         _ = (


### PR DESCRIPTION
As discussed in https://github.com/SubversionRando/SubversionRando/issues/8
this makes the `canOpen` function available for the 4 area doors that require PBs or Supers to open when not in area rando.

This doesn't put the `canOpen` function everywhere it's needed in the logic yet (except for one example at the top).