### PR TITLE
skip_crash_space_port removes the PB requirement to beat the game

### DIFF
--- a/src/subversion_rando/logic_shortcut_data.py
+++ b/src/subversion_rando/logic_shortcut_data.py
@@ -163,6 +163,7 @@ can_win = LogicShortcut(lambda loadout: (
     (GravityBoots in loadout) and
     (Morph in loadout) and
     (loadout.game.daphne_blocks.logic in loadout) and
+    (can_bomb(2) in loadout) and  # wrecked main engineering (2 for exit)
     (pinkDoor in loadout) and  # top entrance to MB
     (  # to enter detonator room
         (loadout.game.options.skip_crash_space_port) or

--- a/src/subversion_rando/logic_shortcut_data.py
+++ b/src/subversion_rando/logic_shortcut_data.py
@@ -161,21 +161,26 @@ can_win = LogicShortcut(lambda loadout: (
     ) and
     (area_doors["RockyRidgeTrailL"] in loadout) and
     (GravityBoots in loadout) and
+    (Morph in loadout) and
     (loadout.game.daphne_blocks.logic in loadout) and
     (pinkDoor in loadout) and  # top entrance to MB
-    (
+    (  # to enter detonator room
         (loadout.game.options.skip_crash_space_port) or
         # skip_crash_space_port option removes the PB requirement
-        (can_use_pbs(1) in loadout) and  # to enter detonator room
+        (can_use_pbs(1) in loadout)
         # 1 because there's an enemy in the room where you need 2 pbs, that normally drops 10 ammo
     ) and
-    
+
     # This next part for leaving the detonator room
-    # TODO: add tricks
-    # (aqua suit because of the acid that starts rising up)
+
+    # to deal with the acid that starts rising up
+    (loadout.has_any(Aqua, Tricks.movement_moderate, can_use_pbs(4), Speedball)) and
+
+    # 2-tile space morph jump if you can't power bomb
     # (4 PBs is mostly for getting out after MB2, but also
     # because there was no opportunity to refill after the last one you used to get in)
-    ((Speedball in loadout) or (Aqua in loadout) or (can_bomb(4) in loadout)) and
+    ((Speedball in loadout) or (can_bomb(4) in loadout)) and
+
     # MB1, zebs, and glass (separate from pinkDoor to prepare for door cap rando)
     (missileDamage in loadout) and
     # kill MB 2

--- a/src/subversion_rando/logic_shortcut_data.py
+++ b/src/subversion_rando/logic_shortcut_data.py
@@ -163,9 +163,13 @@ can_win = LogicShortcut(lambda loadout: (
     (GravityBoots in loadout) and
     (loadout.game.daphne_blocks.logic in loadout) and
     (pinkDoor in loadout) and  # top entrance to MB
-    (can_use_pbs(1) in loadout) and  # to enter detonator room
-    # 1 because there's an enemy in the room where you need 2 pbs, that normally drops 10 ammo
-
+    (
+        (loadout.game.options.skip_crash_space_port) or
+        # skip_crash_space_port option removes the PB requirement
+        (can_use_pbs(1) in loadout) and  # to enter detonator room
+        # 1 because there's an enemy in the room where you need 2 pbs, that normally drops 10 ammo
+    ) and
+    
     # This next part for leaving the detonator room
     # TODO: add tricks
     # (aqua suit because of the acid that starts rising up)

--- a/src/subversion_rando/main_generation.py
+++ b/src/subversion_rando/main_generation.py
@@ -329,7 +329,10 @@ def apply_rom_patches(game: Game, romWriter: RomWriter) -> None:
     patch_open_escape(romWriter)
 
     if game.options.skip_crash_space_port:
+        # Crash GFS Daphne room starts in crashed state
         romWriter.writeBytes(0x07BAA1, b'\x35\xE6')  # also use state (skip test for state 1D)
+        # Wrecked Engineering Room uses escape level data to remove PB requirement
+        romWriter.writeBytes(0x07E06B, b'\x7D\xCB\xC6') # change level data pointer
 
 
 def get_spoiler(game: Game) -> str:


### PR DESCRIPTION
This is implemented by changing the Wrecked Maintenance Deck to use the level data of the escape which does not require PBs.